### PR TITLE
Prevent pointer underflow in trimtrailingspace (fix Access Violation)

### DIFF
--- a/SRC/NPPTextFX.cpp
+++ b/SRC/NPPTextFX.cpp
@@ -3674,8 +3674,8 @@ EXTERNC unsigned trimtrailingspace(char *dest,unsigned *destlen) {
     for(d=dest,end=dest+*destlen;d<end; ) {
       dp=d;
       d=memcspn(d,end,"\r\n",2);
-      for(d--,lold=0; d>=dp && *d==' '; d--, lold++);
-      d++;
+      lold=0;
+      while(d>dp && d[-1]==' ') { d--; lold++; }
       if (lnew != lold) {
         memmovetest(d+lnew,d+lold,*destlen-(d-dest)-lold+1);
         *destlen += lnew-lold;


### PR DESCRIPTION
### Motivation
- Prevent undefined pointer arithmetic in `trimtrailingspace` that could decrement the pointer before the start of the current line and cause an access violation when running "Trim Trailing Spaces".

### Description
- Replaced the reverse-scan loop `for(d--, lold=0; d>=dp && *d==' '; d--, lold++); d++;` with a bounds-safe traversal `lold=0; while (d>dp && d[-1]==' ') { d--; lold++; }` in `SRC/NPPTextFX.cpp` to avoid pointer underflow while preserving trimming behavior.
- Change is limited to the `trimtrailingspace` function and does not alter the trimming semantics.

### Testing
- No automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949e59856c8328884e267972727996)