### PR TITLE
Harden trim trailing spaces buffer handling

### DIFF
--- a/SRC/NPPTextFX.cpp
+++ b/SRC/NPPTextFX.cpp
@@ -3667,27 +3667,31 @@ failbreak:
 }
 
 EXTERNC unsigned trimtrailingspace(char *dest,unsigned *destlen) {
-#define lnew 0
-  unsigned n=0,lold;
+  unsigned n=0;
   char *d,*lineend,*trimstart,*end;
-  if (dest) {
-    for(d=dest,end=dest+*destlen;d<end; ) {
+  if (dest && destlen) {
+    for(d=dest,end=dest+*destlen; d<end; ) {
+      unsigned remove_len;
+      size_t tail_len;
+
       lineend=memcspn(d,end,"\r\n",2);
       trimstart=lineend;
       while(trimstart>d && (trimstart[-1]==' ' || trimstart[-1]=='\t')) trimstart--;
-      lold=(unsigned)(lineend-trimstart);
-      if (lnew != lold) {
-        memmove(trimstart+lnew,lineend,*destlen-(unsigned)(lineend-dest));
-        *destlen += lnew-lold;
-        end += lnew-lold;
-        n++;
+
+      remove_len=(unsigned)(lineend-trimstart);
+      if (remove_len) {
+        tail_len=(size_t)(*destlen-(unsigned)(lineend-dest));
+        memmove(trimstart,lineend,tail_len);
+        *destlen -= remove_len;
+        end -= remove_len;
         lineend=trimstart;
+        n++;
       }
+
       d=memspn(lineend,end,"\r\n",2);
     }
   }
   return(n);
-#undef lnew
 }
 
 // http://www.crimsoneditor.com/english/board/CrazyWWWBoard.cgi?db=forum&mode=read&num=2339&page=161&ftype=6&fval=&backdepth=1


### PR DESCRIPTION
### Motivation
- Prevent an Access Violation observed when running the "Trim Trailing Spaces" action by eliminating risky unsigned/negative pointer arithmetic and adding defensive checks.
- The previous implementation relied on `lnew - lold` with `lnew == 0` which can produce unsigned wraparound and unsafe pointer math, and also could dereference a null `destlen` pointer.

### Description
- Rewrote `trimtrailingspace` in `SRC/NPPTextFX.cpp` to compute an explicit `remove_len` and `tail_len` instead of using the `lnew` macro and unsigned underflow semantics.
- Added a defensive guard `if (dest && destlen)` to avoid dereferencing a null `destlen` pointer.
- Use `memmove(trimstart, lineend, tail_len)` and clear subtractive updates `*destlen -= remove_len; end -= remove_len;` to adjust buffer length and end pointer safely while preserving existing behavior of removing trailing spaces/tabs before line endings.

### Testing
- Ran static sanity checks with `git diff --check` which reported no issues and basic repository status inspection which showed the modified file; both checks succeeded.
- No unit tests were available for this function in the tree, and no full build or runtime test was executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e599cde88328996c591ed4c27ba1)