### PR TITLE
Refresh TextFX menu labels on notifications to fix delayed ANSI startup init

### DIFF
--- a/SRC/NPPTextFX.cpp
+++ b/SRC/NPPTextFX.cpp
@@ -7364,45 +7364,63 @@ extern "C" __declspec(dllexport) BOOL isUnicode() {
 }
 #endif
 
+EXTERNC BOOL RefreshTextFXMenuLabels(void) {
+  int nbF=0;
+  BOOL modified=FALSE;
+  BOOL success=FALSE;
+  struct FuncItem *fi=getFuncsArray(&nbF);
+  HMENU hMainMenu=GetMenu(g_nppData._nppHandle);
+  if (!fi || !hMainMenu) return FALSE;
+
+  unsigned mii;
+  for(mii=0; mii<(unsigned)nbF; mii++) {
+    NPPCHAR *label=fi[mii]._itemName;
+    if (!label) continue;
+    if (label[0] && label[1]==NPPTEXT(':')) label+=2;
+    if (label[0]==NPPTEXT('-') && !label[1]) {
+#ifdef NPP_UNICODE
+      if (ModifyMenuW(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_SEPARATOR,fi[mii]._cmdID,NULL)) {
+#else
+      if (ModifyMenuA(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_SEPARATOR,fi[mii]._cmdID,NULL)) {
+#endif
+        modified=TRUE;
+        success=TRUE;
+      }
+    } else {
+#ifdef NPP_UNICODE
+      if (ModifyMenuW(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_STRING,fi[mii]._cmdID,label)) {
+#else
+      if (ModifyMenuA(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_STRING,fi[mii]._cmdID,label)) {
+#endif
+        modified=TRUE;
+        success=TRUE;
+      }
+    }
+  }
+  if (modified) DrawMenuBar(g_nppData._nppHandle);
+  return success;
+}
+
 // If you don't need get the notification from Notepad++,
 // just let it be empty.
 extern "C" __declspec(dllexport) void beNotified(struct SCNotification *notifyCode) {
   static unsigned runonce=0;
   static unsigned prevline;
   static BOOL block=FALSE;
+  static BOOL menuLabelsCleaned=FALSE;
   BOOL kscapital;
   static char chPerformKey='\0';
   INT_CURRENTEDIT;
 
 if (!block) { // with enough delay, beNotified ends up rentrant
   block=TRUE;
+  if (!menuLabelsCleaned) menuLabelsCleaned=RefreshTextFXMenuLabels();
   if (!runonce && g_fLoadonce) {
-    unsigned mii;
-    int nbF=0;
-    struct FuncItem *fi=getFuncsArray(&nbF);
-    HMENU hMainMenu=GetMenu(g_nppData._nppHandle);
     pfbuildmenu();
-    for(mii=0; fi && mii<(unsigned)nbF; mii++) {
-      NPPCHAR *label=fi[mii]._itemName;
-      if (label[0] && label[1]==NPPTEXT(':')) label+=2;
-      if (label[0]==NPPTEXT('-') && !label[1]) {
-#ifdef NPP_UNICODE
-        ModifyMenuW(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_SEPARATOR,fi[mii]._cmdID,NULL);
-#else
-        ModifyMenuA(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_SEPARATOR,fi[mii]._cmdID,NULL);
-#endif
-      } else {
-#ifdef NPP_UNICODE
-        ModifyMenuW(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_STRING,fi[mii]._cmdID,label);
-#else
-        ModifyMenuA(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_STRING,fi[mii]._cmdID,label);
-#endif
-      }
-    }
+    menuLabelsCleaned=RefreshTextFXMenuLabels();
 #if ENABLE_TIDYDLL
     control_tidy(FALSE);
 #endif
-    DrawMenuBar(g_nppData._nppHandle);
     CloseHandle(g_fLoadonce); // closing here will allow another invocation of Notepad++ + NPPTextFX to load if N++ allows this
     g_fLoadonce=NULL;
     if (!funcItem[g_miDisableSubclassing]._init2Check) {


### PR DESCRIPTION
### Motivation
- When Notepad++ starts in the ANSI-file case the TextFX submenu can be left with raw prefixes like `E:`, `Q:`, `W:` and with `-` shown as text instead of separators due to delayed menu initialization. 
- The change makes menu-label cleanup robust against startup-ordering delays by re-running the normalization when notifications arrive.

### Description
- Added `RefreshTextFXMenuLabels()` which iterates the `funcItem` array, strips the leading prefix (e.g. `X:`), converts `"-"` entries into `MF_SEPARATOR` and updates labels via `ModifyMenuA`/`ModifyMenuW`, and calls `DrawMenuBar()` when modifications occur. 
- `beNotified(...)` now tracks `menuLabelsCleaned` and calls `RefreshTextFXMenuLabels()` before and after the existing `pfbuildmenu()` path so delayed initialization is fixed from notifications as well. 
- Replaced the previous duplicated inline `ModifyMenu` code in `beNotified(...)` with the new helper to centralize label normalization.

### Testing
- Applied the patch successfully with the repository patch tool and the source file updated without patch errors. 
- Ran a diff/check pass (no whitespace or diff errors found). 
- Attempted to compare implementation patterns against `xmltools` upstream but network access to clone that repo failed in this environment, so network-based cross-references were not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994fd75de188328b440ddf59c63d4af)