### PR TITLE
Fix regression: keep TextFX menu visible while retaining delayed label cleanup

### DIFF
--- a/SRC/NPPTextFX.cpp
+++ b/SRC/NPPTextFX.cpp
@@ -7364,45 +7364,67 @@ extern "C" __declspec(dllexport) BOOL isUnicode() {
 }
 #endif
 
+EXTERNC BOOL RefreshTextFXMenuLabels(void) {
+  int nbF=0;
+  BOOL modified=FALSE;
+  BOOL success=FALSE;
+  BOOL hasValidCmdID=FALSE;
+  struct FuncItem *fi=getFuncsArray(&nbF);
+  HMENU hMainMenu=GetMenu(g_nppData._nppHandle);
+  if (!fi || !hMainMenu) return FALSE;
+
+  unsigned mii;
+  for(mii=0; mii<(unsigned)nbF; mii++) {
+    NPPCHAR *label=fi[mii]._itemName;
+    UINT cmdID=(UINT)fi[mii]._cmdID;
+    if (!label || !cmdID) continue;
+    hasValidCmdID=TRUE;
+    if (label[0] && label[1]==NPPTEXT(':')) label+=2;
+    if (label[0]==NPPTEXT('-') && !label[1]) {
+#ifdef NPP_UNICODE
+      if (ModifyMenuW(hMainMenu,cmdID,MF_BYCOMMAND|MF_SEPARATOR,cmdID,NULL)) {
+#else
+      if (ModifyMenuA(hMainMenu,cmdID,MF_BYCOMMAND|MF_SEPARATOR,cmdID,NULL)) {
+#endif
+        modified=TRUE;
+        success=TRUE;
+      }
+    } else {
+#ifdef NPP_UNICODE
+      if (ModifyMenuW(hMainMenu,cmdID,MF_BYCOMMAND|MF_STRING,cmdID,label)) {
+#else
+      if (ModifyMenuA(hMainMenu,cmdID,MF_BYCOMMAND|MF_STRING,cmdID,label)) {
+#endif
+        modified=TRUE;
+        success=TRUE;
+      }
+    }
+  }
+  if (!hasValidCmdID) return FALSE;
+  if (modified) DrawMenuBar(g_nppData._nppHandle);
+  return success;
+}
+
 // If you don't need get the notification from Notepad++,
 // just let it be empty.
 extern "C" __declspec(dllexport) void beNotified(struct SCNotification *notifyCode) {
   static unsigned runonce=0;
   static unsigned prevline;
   static BOOL block=FALSE;
+  static BOOL menuLabelsCleaned=FALSE;
   BOOL kscapital;
   static char chPerformKey='\0';
   INT_CURRENTEDIT;
 
 if (!block) { // with enough delay, beNotified ends up rentrant
   block=TRUE;
+  if (!menuLabelsCleaned && !g_fLoadonce) menuLabelsCleaned=RefreshTextFXMenuLabels();
   if (!runonce && g_fLoadonce) {
-    unsigned mii;
-    int nbF=0;
-    struct FuncItem *fi=getFuncsArray(&nbF);
-    HMENU hMainMenu=GetMenu(g_nppData._nppHandle);
     pfbuildmenu();
-    for(mii=0; fi && mii<(unsigned)nbF; mii++) {
-      NPPCHAR *label=fi[mii]._itemName;
-      if (label[0] && label[1]==NPPTEXT(':')) label+=2;
-      if (label[0]==NPPTEXT('-') && !label[1]) {
-#ifdef NPP_UNICODE
-        ModifyMenuW(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_SEPARATOR,fi[mii]._cmdID,NULL);
-#else
-        ModifyMenuA(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_SEPARATOR,fi[mii]._cmdID,NULL);
-#endif
-      } else {
-#ifdef NPP_UNICODE
-        ModifyMenuW(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_STRING,fi[mii]._cmdID,label);
-#else
-        ModifyMenuA(hMainMenu,fi[mii]._cmdID,MF_BYCOMMAND|MF_STRING,fi[mii]._cmdID,label);
-#endif
-      }
-    }
+    menuLabelsCleaned=RefreshTextFXMenuLabels();
 #if ENABLE_TIDYDLL
     control_tidy(FALSE);
 #endif
-    DrawMenuBar(g_nppData._nppHandle);
     CloseHandle(g_fLoadonce); // closing here will allow another invocation of Notepad++ + NPPTextFX to load if N++ allows this
     g_fLoadonce=NULL;
     if (!funcItem[g_miDisableSubclassing]._init2Check) {


### PR DESCRIPTION
### Motivation
- A previous change attempted to normalize TextFX menu labels early from notifications and could call `ModifyMenu*` when command IDs were not yet valid, which made the TextFX menu disappear.
- The intent is to keep the delayed ANSI startup label cleanup while avoiding unsafe early menu mutations that break menu visibility.

### Description
- Hardened `RefreshTextFXMenuLabels()` to skip entries with no label or with `_cmdID == 0`, track `hasValidCmdID`, and return `FALSE` when no valid command IDs are present so no unsafe `ModifyMenu*` calls are performed.
- Adjusted the `beNotified(...)` flow to call `RefreshTextFXMenuLabels()` early only when `!g_fLoadonce` and to retain the post-`pfbuildmenu()` cleanup call, and introduced a static `menuLabelsCleaned` flag to avoid repeated unsafe attempts.
- These changes preserve the normalization behavior for delayed ANSI startup while preventing menu disappearance caused by operating on the main menu too early.

### Testing
- Ran `git diff --check` on the modified source and the check passed without spacing/diff errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994fd75de188328b440ddf59c63d4af)